### PR TITLE
Use PackageMaterialProperty instead of Property in ConfigurationProvider...

### DIFF
--- a/developer/writing_go_plugins/package_material/writing_go_package_material_plugin.md
+++ b/developer/writing_go_plugins/package_material/writing_go_package_material_plugin.md
@@ -79,9 +79,9 @@ The configuration provider should implement PackageMaterialConfiguration interfa
     ``` {.code}
         public RepositoryConfiguration getRepositoryConfiguration() {
             RepositoryConfiguration repositoryConfiguration = new RepositoryConfiguration();
-            repositoryConfiguration.add(new Property("REPO_URL").with(Property.DISPLAY_NAME, "Repository Url").with(Property.DISPLAY_ORDER, 0));
-            repositoryConfiguration.add(new Property("USERNAME").with(Property.DISPLAY_NAME, "Username").with(Property.DISPLAY_ORDER, 1));
-            repositoryConfiguration.add(new Property("PASSWORD").with(Property.DISPLAY_NAME, "Password").with(Property.DISPLAY_ORDER, 2));
+            repositoryConfiguration.add(new PackageMaterialProperty("REPO_URL").with(Property.DISPLAY_NAME, "Repository Url").with(Property.DISPLAY_ORDER, 0));
+            repositoryConfiguration.add(new PackageMaterialProperty("USERNAME").with(Property.DISPLAY_NAME, "Username").with(Property.DISPLAY_ORDER, 1));
+            repositoryConfiguration.add(new PackageMaterialProperty("PASSWORD").with(Property.DISPLAY_NAME, "Password").with(Property.DISPLAY_ORDER, 2));
             return repositoryConfiguration;
         }
                     
@@ -92,7 +92,7 @@ The configuration provider should implement PackageMaterialConfiguration interfa
     ``` {.code}
         public PackageConfiguration getPackageConfiguration() {
             PackageConfiguration packageConfiguration = new PackageConfiguration();
-            packageConfiguration.add(new Property("PACKAGE_DETAILS"));
+            packageConfiguration.add(new PackageMaterialProperty("PACKAGE_DETAILS"));
             return packageConfiguration;
         }
                     


### PR DESCRIPTION
... documentation

Adding Property properties is incorrect; both the example Yum and Debian repository pollers use PackageMaterialProperty here rather than what's in this documentation, which leads to an internal exception:

2014-11-15 00:13:44,612 ERROR [Thread-63] FelixGoPluginOSGiFramework:113 - Failed to load plugin: plugins_work\sd-plugin.jar
java.lang.RuntimeException: com.thoughtworks.go.plugin.api.config.Property cannot be cast to java.lang.Comparable
	at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.executeActionOnTheService(FelixGoPluginOSGiFramework.java:306)
	at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.doOnWithExceptionHandling(FelixGoPluginOSGiFramework.java:262)
	at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.doOn(FelixGoPluginOSGiFramework.java:248)
	at com.thoughtworks.go.plugin.infra.DefaultPluginManager.doOn(DefaultPluginManager.java:85)
	at com.thoughtworks.go.plugin.infra.DefaultPluginManager.doOnIfHasReference(DefaultPluginManager.java:91)
	at com.thoughtworks.go.plugin.access.packagematerial.PackageMaterialMetadataLoader.fetchRepositoryAndPackageMetaData(PackageMaterialMetadataLoader.java:51)
	at com.thoughtworks.go.plugin.access.packagematerial.PackageMaterialMetadataLoader.pluginLoaded(PackageMaterialMetadataLoader.java:67)
	at com.thoughtworks.go.plugin.infra.DefaultPluginManager$FilterChangeListener.pluginLoaded(DefaultPluginManager.java:155)
	at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework$2.execute(FelixGoPluginOSGiFramework.java:351)
	at org.apache.commons.collections.CollectionUtils.forAllDo(CollectionUtils.java:386)
	at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.getBundle(FelixGoPluginOSGiFramework.java:110)
	at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.loadPlugin(FelixGoPluginOSGiFramework.java:96)
	at com.thoughtworks.go.plugin.infra.listeners.DefaultPluginJarChangeListener.refreshBundle(DefaultPluginJarChangeListener.java:152)
	at com.thoughtworks.go.plugin.infra.listeners.DefaultPluginJarChangeListener.addPlugin(DefaultPluginJarChangeListener.java:109)
	at com.thoughtworks.go.plugin.infra.listeners.DefaultPluginJarChangeListener.pluginJarAdded(DefaultPluginJarChangeListener.java:72)
	at com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor$PluginLocationMonitorThread$DoOnAllListeners$1.execute(DefaultPluginJarLocationMonitor.java:266)
	at com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor$PluginLocationMonitorThread$DoOnAllListeners.doOnAll(DefaultPluginJarLocationMonitor.java:297)
	at com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor$PluginLocationMonitorThread$DoOnAllListeners.pluginJarAdded(DefaultPluginJarLocationMonitor.java:264)
	at com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor$PluginLocationMonitorThread.notifyListenersOfAddedPlugins(DefaultPluginJarLocationMonitor.java:195)
	at com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor$PluginLocationMonitorThread.loadAndNotifyPluginsFrom(DefaultPluginJarLocationMonitor.java:186)
	at com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor$PluginLocationMonitorThread.run(DefaultPluginJarLocationMonitor.java:172)
Caused by: java.lang.ClassCastException: com.thoughtworks.go.plugin.api.config.Property cannot be cast to java.lang.Comparable
	at java.util.Collections.sort(Unknown Source)
	at com.thoughtworks.go.plugin.api.material.packagerepository.RepositoryConfiguration.list(Unknown Source)
	at com.thoughtworks.go.plugin.access.packagematerial.PackageConfigurations.<init>(PackageConfigurations.java:37)
	at com.thoughtworks.go.plugin.access.packagematerial.PackageMaterialMetadataLoader$1.execute(PackageMaterialMetadataLoader.java:54)
	at com.thoughtworks.go.plugin.access.packagematerial.PackageMaterialMetadataLoader$1.execute(PackageMaterialMetadataLoader.java:51)
	at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.executeActionOnTheService(FelixGoPluginOSGiFramework.java:301)
	... 20 more