### PR TITLE
Correct Go agent install link in server install footer

### DIFF
--- a/user/installation/install/server/_install_server_footer.md
+++ b/user/installation/install/server/_install_server_footer.md
@@ -8,7 +8,7 @@ To do this Administrator should copy ```cruise-config.xml``` from the config dir
 
 **Also see...**
 
-- [Installing Go agents](installing_go_agent.md)
+- [Installing Go agents](../../installing_go_agent.md)
 - [Configuring server details](configuring_server_details.md)
 - [Configure Go to work with a proxy](configure_proxy.md)
 - [Backing up a go server](../../../advanced_usage/one_click_backup.md)


### PR DESCRIPTION
This fixes a broken link in the server install footer.