### PR TITLE
Fix IntelliJ Development Server config according to latest src code

### DIFF
--- a/developer/2/2.1.md
+++ b/developer/2/2.1.md
@@ -169,11 +169,11 @@ The IDEA **Application** run-configuration can be setup using the values below:
 
 ```
 Name: Development Server
-Main Class: com.thoughtworks.go.server.DevelopmentServerNewJRuby
+Main Class: com.thoughtworks.go.server.DevelopmentServer
 VM options: -Xms512m -Xmx1024m -XX:PermSize=400m
 Working directory: <project-directory>/server
 Environment variables: GEM_PATH=;GEM_HOME=;
-Use classpath of module: development-server-new-jruby
+Use classpath of module: development-server
 ```
 
 Configuring IntelliJ IDEA *run-configuration*


### PR DESCRIPTION
For IDEA Application run-configuration of `2.1.4 Running Development Server via IntelliJ IDEA`

`DevelopmentServerNewJRuby` is no longer exists, so is `development-server-new-jruby` module