### PR TITLE
remove trust.jks for multiple agents setup

### DIFF
--- a/user/advanced_usage/admin_install_multiple_agents.md
+++ b/user/advanced_usage/admin_install_multiple_agents.md
@@ -13,6 +13,7 @@ On Windows, multiple Go agents can be run in two ways - as Windows service or as
 - [Install your first agent with the installer to the default location](../installation/installing_go_agent.md)
 - Copy the installation folder ("C:\\Program Files\\Go Agent") to "C:\\Program Files\\Go Agent 2"
 - Delete the file C:\\Program Files\\Go Agent 2\\config\\guid.txt
+- Delete the file C:\\Program Files\\Go Agent 2\\config\\trust.jks
 - Delete the file C:\\Program Files\\Go Agent 2\\.agent-bootstrapper.running
 - Edit **wrapper-agent.conf** file to customise information related to **Go Agent 2**
 Just after the line \#include ../conf/wrapper-licenses.conf, add


### PR DESCRIPTION
Setting up multiple agents of Windows starts but raises SSL exception. Need to remove previous trust.jks to get it right; it get regenerated.