### PR TITLE
Use XML Github-Flavored Markdown for plugins.xml example

### DIFF
--- a/developer/writing_go_plugins/go_plugins_basics.md
+++ b/developer/writing_go_plugins/go_plugins_basics.md
@@ -41,24 +41,24 @@ Plugin metadata is a file that should be at the top level of the plugin JAR file
 
 Following is a sample plugin.xml file:
 
-``` {.code}
-                <?xml version="1.0" encoding="utf-8" ?>
-                <go-plugin id="testplugin.somePlugin" version="1">
-                    <about>
-                        <name>Some plugin name</name>
-                        <version>1.0.1</version>
-                        <target-go-version>12.4</target-go-version>
-                        <description>Some description goes here</description>
-                        <vendor>
-                            <name>ThoughtWorks Go Team</name>
-                            <url>www.thoughtworks.com</url>
-                        </vendor>
-                        <target-os>
-                            <value>Linux</value>
-                            <value>Windows</value>
-                        </target-os>
-                    </about>
-                </go-plugin>
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<go-plugin id="testplugin.somePlugin" version="1">
+    <about>
+        <name>Some plugin name</name>
+        <version>1.0.1</version>
+        <target-go-version>12.4</target-go-version>
+        <description>Some description goes here</description>
+        <vendor>
+            <name>ThoughtWorks Go Team</name>
+            <url>www.thoughtworks.com</url>
+        </vendor>
+        <target-os>
+            <value>Linux</value>
+            <value>Windows</value>
+        </target-os>
+    </about>
+</go-plugin>
             
 ```
 


### PR DESCRIPTION
Also clean up indentation to allow for easy copying.

In the current documentation the xml tags are hidden:
![screen shot 2015-10-12 at 11 11 52 pm](https://cloud.githubusercontent.com/assets/230004/10447246/bceaf51e-7137-11e5-9351-3e8ff3446630.png)

Changing the code fence to xml shows and syntax highlights the tags:

![screen shot 2015-10-12 at 11 12 27 pm](https://cloud.githubusercontent.com/assets/230004/10447256/d3cf7340-7137-11e5-8690-c97f20411a4a.png)
