### PR TITLE
Update RSpec Instructions

### DIFF
--- a/developer/6/6.2.md
+++ b/developer/6/6.2.md
@@ -17,15 +17,15 @@ You can find them under `server/webapp/WEB-INF/rails/spec` folder.
 These tests can be executed from command prompt as well as individually from your editor. 
 To run all rspec tests from commandline, execute the following:
 
-`./tools/bin/old.go.jruby -S rake --rakefile server/run_rspec_tests.rake spec`
+`./tools/bin/go.jruby -S rake --rakefile server/run_rspec_tests.rake spec`
 
 To run a subset, a pattern could be specified, for instance:
 
-`spec_module=helpers/api ./tools/bin/old.go.jruby -S rake --rakefile server/run_rspec_tests.rake spec`
+`spec_module=helpers/api ./tools/bin/go.jruby -S rake --rakefile server/run_rspec_tests.rake spec`
 
 OR
 
-`spec_module=views/[a-z]* ./tools/bin/old.go.jruby -S rake --rakefile server/run_rspec_tests.rake spec`
+`spec_module=views/[a-z]* ./tools/bin/go.jruby -S rake --rakefile server/run_rspec_tests.rake spec`
 
 Alternately, you could have a spec server running while you code, and you could run individual test as and when you make changes to any of the rails code. 
 `server/webapp/WEB-INF/rails/script/spec -X <file path> -l <line number>` with `server/webapp/WEB-INF/rails` as the working directory.


### PR DESCRIPTION
`./tools/bin/old.go.jruby` is no longer included in the project, but `./tools/bin/go.jruby` is.