### PR TITLE
Parameters:  Add missing "in", and simplify sentence.

### DIFF
--- a/user/configuration/admin_use_parameters_in_configuration.md
+++ b/user/configuration/admin_use_parameters_in_configuration.md
@@ -59,7 +59,7 @@ Parameter usage within [templates](pipeline_templates.md) is similar to usage wi
 
 ```
 
-The parameter defined above is used the template below.
+The parameter is used in the template below.
 
 ```xml
 <pipeline name="my_template">


### PR DESCRIPTION
"in" was missing from the sentence.  Also "defined above" seemed
superfluous because it's evident from the context, so let's 
simplify the sentence.