### PR TITLE
removing pdf download link from documentation - the tables on config-…

### DIFF
--- a/user/book.json
+++ b/user/book.json
@@ -4,7 +4,6 @@
     "links": {
         "sidebar": {
             "Home": "http://www.go.cd",
-            "Download as PDF": "http://download.go.cd/gocd/user-documentation-15.2.0.pdf",
             "Contribute": "https://github.com/gocd/documentation/"
         },
         "sharing": {


### PR DESCRIPTION
…reference and cnfig-repo pages are broken

Reference was broken for 15.2 as well