### PR TITLE
fix multiple agents setup recommendation

### DIFF
--- a/user/advanced_usage/admin_install_multiple_agents.md
+++ b/user/advanced_usage/admin_install_multiple_agents.md
@@ -55,12 +55,26 @@ sc create GoAgent2 binPath= "\"C:\Program Files\Go Agent2\cruisewrapper.exe\" -s
 - [Install your first agent with the installer](../installation/installing_go_agent.md)
 - To create a second agent on the same host, run this as root:
     ```
-    ln -s /etc/init.d/go-agent /etc/init.d/go-agent-1
+    cp /etc/init.d/go-agent /etc/init.d/go-agent-1
+    sed -i 's/# Provides: go-agent$/# Provides: go-agent-1/g' /etc/init.d/go-agent-1
     ln -s /usr/share/go-agent /usr/share/go-agent-1
     cp /etc/default/go-agent /etc/default/go-agent-1
     mkdir /var/{lib,log}/go-agent-1
     chown go:go /var/{lib,log}/go-agent-1
     ```
+- To enable starting the go-agent service during system boot:
+  - on Debian:
+  ```
+  insserv go-agent-1
+  ```
+  - on Ubuntu:
+  ```
+  update-rc.d go-agent-1 defaults
+  ```
+  - on Centos and Redhat:
+  ```
+  chkconfig go-agent-1 on
+  ```
 
 - You can now start or stop the second agent using /etc/init.d/go-agent-1
   (passing it the start or stop) arguments as usual. Logs will be written to
@@ -77,4 +91,3 @@ sc create GoAgent2 binPath= "\"C:\Program Files\Go Agent2\cruisewrapper.exe\" -s
 ```
 java -jar /usr/share/go-agent/agent-bootstrapper.jar 127.0.0.1 &
 ```
-


### PR DESCRIPTION
This is a tested method. The one previously provided would never start on reboot and could not be enabled to start on boot at all.

Problem description in https://github.com/gocd-contrib/go-cookbook/issues/59