### PR TITLE
configrepo extension docs

### DIFF
--- a/developer/writing_go_plugins/configrepo/configrepo_plugin_overview.md
+++ b/developer/writing_go_plugins/configrepo/configrepo_plugin_overview.md
@@ -1,0 +1,6 @@
+## Overview of configuration repository plugins
+
+Go's user documentation has an overview of configuration repository plugins. Please see [that](http://www.go.cd/documentation/user/current/extension_points/configrepo_extension.html).
+
+Writing a configuration repository plugin:
+* [JSON API - Message based](json_message_based_configrepo_extension.md)

--- a/developer/writing_go_plugins/configrepo/json_message_based_configrepo_extension.md
+++ b/developer/writing_go_plugins/configrepo/json_message_based_configrepo_extension.md
@@ -1,0 +1,28 @@
+# Configuration repository plugin - JSON API - Message based
+
+The objective of this guide is to explain how to write a [configuration repository plugin](configrepo_plugin_overview.md), for Go.
+
+Useful references:
+* [Overview of configuration repository plugins - External link to Go's user documentation](http://www.go.cd/documentation/user/current/extension_points/configrepo_extension.html)
+* [Overview of message-based APIs](../json_message_based_plugin_api.md)
+* [Structure of a plugin and writing one](../go_plugins_basics.md)
+* [A sample Configuration repository plugin - JSON](https://github.com/tomzo/gocd-json-config-plugin)
+
+A configuration repository plugin is a Go plugin, which claims to support to extension name `configrepo` in its identifier, and responds to the messages mentioned below, appropriately.
+
+Go provides a clean checkout of the SCM repository to configuration plugin and expects that plugin will be capable of parsing all necessary files to return pipeline and environment configurations. Therefore any configuration plugin is responsible for:
+
+ * identifying which files to parse in provided directory
+ * parsing and validating files and their format
+ * returning configuration objects and/or errors found in the checkout directory
+
+If configuration object returned by plugin is invalid, Go server will treat related configuration repository as invalid - it will not merge it into current configuration and it will show errors on the dashboard.
+
+## Messages to be handled by the plugin - ***version 1.0***
+
+[Parse directory](version_1_0/parse_directory.md)
+
+## Other information
+
+* Availability: Go version 16.2.0 onwards
+* Extension Name: `configrepo`

--- a/developer/writing_go_plugins/configrepo/json_message_based_configrepo_extension.md
+++ b/developer/writing_go_plugins/configrepo/json_message_based_configrepo_extension.md
@@ -20,7 +20,8 @@ If configuration object returned by plugin is invalid, Go server will treat rela
 
 ## Messages to be handled by the plugin - ***version 1.0***
 
-[Parse directory](version_1_0/parse_directory.md)
+[Parse directory](version_1_0/parse_directory.md) - a small request made by server to parse contents of configuration repository checkout. Then response from plugin contains ALL configuration objects defined in that repository. Since configuration domain is quite big, there is a [dedicated page](version_1_0/config_objects.md) to all object that can be included in response.
+
 
 ## Other information
 

--- a/developer/writing_go_plugins/configrepo/version_1_0/config_objects.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/config_objects.md
@@ -18,9 +18,10 @@ But beware that this is a different model, some of the differences are:
 
 ### Index
 
-1. [Environment](#Environment)
-1. [Pipeline](#Pipeline)
-    * [Mingle](#Mingle)
+1. [Environment](#environment)
+1. [Environment variables](#environment-variables)
+1. [Pipeline](#pipeline)
+    * [Mingle](#mingle)
     * [Tracking tool](#tracking tool)
     * [Timer](#timer)
 1. [Stage](#stage)
@@ -33,7 +34,8 @@ But beware that this is a different model, some of the differences are:
     * [ant](tasks.md#ant)
     * [nant](tasks.md#nant)
     * [exec](tasks.md#exec)
-    * [pluggabletask](tasks.md#pluggable)
+    * [fetch](tasks.md#fetch)
+    * [pluggabletask](tasks.md#plugin)
 1. [Materials](materials.md)
     * [dependency](materials.md#dependency)
     * [package](materials.md#package)
@@ -63,6 +65,27 @@ Configures a [Go environment](http://www.go.cd/documentation/user/current/config
   ],
   "pipelines": [
     "mypipeline1"
+  ]
+}
+```
+
+# Environment variables
+
+Environment variables is a JSON array that can be declared in Environments, Pipelines, Stages and Jobs.
+
+Any variable must contain `name` and `value` or `encrypted_value`.
+
+```json
+{
+  "environment_variables": [
+    {
+      "name": "key1",
+      "value": "value1"
+    },
+    {
+      "name": "keyd",
+      "encrypted_value": "v12@SDfwez"
+    }
   ]
 }
 ```

--- a/developer/writing_go_plugins/configrepo/version_1_0/config_objects.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/config_objects.md
@@ -1,0 +1,216 @@
+# Configuration objects supported by `configrepo` extension point
+
+This page should be used as reference on valid configuration objects in `configrepo` extension point.
+All these can be part of response for [parse-directory message](parse_directory.md)
+
+## Similarity to API
+
+Objects used by extension point are similar to one in the [Go API](https://api.go.cd/current).
+But beware that this is a different model, some of the differences are:
+
+ * pipeline declares `group` which it belongs to.
+ * object tree is more "flat" here. E.g. `"run_if" : "passed"`  vs `"run_if" : [ "passed" ]` in API.
+ * there is no split between `type` and `attributes` in JSON objects
+
+## Location field
+
+`location` is optional field on all JSON objects. It is used to generate error messages and might be used in future UI to show origin of configuration element. It is recommended to assign `location` a relative file path and/or line of the configuration element.
+
+### Index
+
+1. [Environment](#Environment)
+1. [Pipeline](#Pipeline)
+    * [Mingle](#Mingle)
+    * [Tracking tool](#tracking tool)
+    * [Timer](#timer)
+1. [Stage](#stage)
+    * [Approval](#approval)
+1. [Job](#job)
+    * [Property](#property)
+    * [Tab](#tab)
+1. [Tasks](tasks.md)
+    * [rake](tasks.md#rake)
+    * [ant](tasks.md#ant)
+    * [nant](tasks.md#nant)
+    * [exec](tasks.md#exec)
+    * [pluggabletask](tasks.md#pluggable)
+1. [Materials](materials.md)
+    * [dependency](materials.md#dependency)
+    * [package](materials.md#package)
+    * [git](materials.md#git)
+    * [svn](materials.md#svn)
+    * [perforce](materials.md#perforce)
+    * [tfs](materials.md#tfs)
+    * [hg](materials.md#hg)
+    * [pluggable scm](materials.md#pluggable)
+
+# Environment
+
+Configures a [Go environment](http://www.go.cd/documentation/user/current/configuration/managing_environments.html)
+
+```json
+{
+  "location" : "src/environments/dev.yaml",
+  "name": "dev",
+  "environment_variables": [
+    {
+      "name": "key1",
+      "value": "value1"
+    }
+  ],
+  "agents": [
+    "123"
+  ],
+  "pipelines": [
+    "mypipeline1"
+  ]
+}
+```
+
+# Pipeline
+
+```json
+{
+  "location" : "src/pipelines/pipe2.yaml",
+  "group": "group1",
+  "name": "pipe2",
+  "label_template": "foo-1.0-${COUNT}",
+  "enable_pipeline_locking": true,
+  "mingle": {
+    "base_url": "http://mingle.example.com",
+    "project_identifier": "my_project"
+  },
+  "tracking_tool": null,
+  "timer": {
+    "spec": "0 15 10 * * ? *"
+  },
+  "environment_variables": [],
+  "materials": [
+    ...
+  ],
+  "stages": [
+    ...
+  ]
+}
+```
+
+Please note:
+
+ * templates are not supported
+ * parameters are not supported
+ * pipeline declares a group to which it belongs
+
+### Mingle
+
+```json
+{
+    "base_url": "https://mingle.example.com",
+    "project_identifier": "foobar_widgets",
+    "mql_grouping_conditions": "status > 'In Dev'"
+}
+```
+
+### Tracking tool
+
+```json
+{
+  "link": "http://your-trackingtool/yourproject/${ID}",
+  "regex": "evo-(\\d+)"
+}
+```
+
+### Timer
+
+```json
+{
+    "spec": "0 0 22 ? * MON-FRI",
+    "only_on_changes": true
+}
+```
+
+# Stage
+
+```json
+{
+  "name": "test",
+  "fetch_materials": true,
+  "never_cleanup_artifacts": false,
+  "clean_working_directory": false,
+  "approval" : null,
+  "environment_variables": [
+    {
+      "name": "TEST_NUM",
+      "value": "1"
+    }
+  ],
+  "jobs": [
+    ...
+  ]
+}
+```
+
+### Approval
+
+```json
+{
+  "type": "manual",
+  "users": [],
+  "roles": [
+    "manager"
+  ]
+}
+```
+
+# Job
+
+```json
+{
+  "name": "test",
+  "environment_variables": [],
+  "tabs": [
+     {
+       "name": "test",
+       "path": "results.xml"
+     }
+   ],
+   "resources": [
+    "linux"
+  ],
+  "artifacts": [
+    {
+      "source": "src",
+      "destination": "dest",
+      "type": "test"
+    }
+  ],
+  "properties": [
+    {
+      "name": "perf",
+      "source": "test.xml",
+      "xpath": "substring-before(//report/data/all/coverage[starts-with(@type,\u0027class\u0027)]/@value, \u0027%\u0027)"
+    }
+  ],
+  "tasks": [
+    ...
+  ]
+}
+```
+
+### Property
+
+```json
+{
+  "name": "coverage.class",
+  "source": "target/emma/coverage.xml",
+  "xpath": "substring-before(//report/data/all/coverage[starts-with(@type,'class')]/@value, '%')"
+}
+```
+
+### Tab
+
+```json
+{
+      "name": "cobertura",
+      "path": "target/site/cobertura/index.html"
+}
+```

--- a/developer/writing_go_plugins/configrepo/version_1_0/materials.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/materials.md
@@ -142,5 +142,16 @@ which usually makes more sense considering that value is stored in SCM.
 ## Pluggable SCM
 
 ```json
-
+{
+  "scm_id": "someScmGitRepositoryId",
+  "destination": "destinationDir",
+  "filter": {
+    "ignore": [
+      "dir1",
+      "dir2"
+    ]
+  },
+  "name": "myPluggableGit",
+  "type": "plugin"
+}
 ```

--- a/developer/writing_go_plugins/configrepo/version_1_0/materials.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/materials.md
@@ -1,0 +1,146 @@
+# Material objects in `configrepo` extension point
+
+All materials:
+
+ * must have `type` - `git`, `svn`, `hg`, `p4`, `tfs`, `dependency`, `package`, `plugin`.
+ * can have `name` and must have `name` when there is more than one material in pipeline
+
+SCM-related materials have `destination` field.
+
+## Git
+
+```json
+{
+  "url": "http://my.git.repository.com",
+  "branch": "feature12",
+  "filter": {
+    "ignore": [
+      "externals",
+      "tools"
+    ]
+  },
+  "destination": "dir1",
+  "auto_update": false,
+  "name": "gitMaterial1",
+  "type": "git"
+}
+```
+
+## Svn
+
+```json
+{
+  "url": "http://svn",
+  "username": "user1",
+  "password": "pass1",
+  "check_externals": true,
+  "filter": {
+    "ignore": [
+      "tools",
+      "lib"
+    ]
+  },
+  "destination": "destDir1",
+  "auto_update": false,
+  "name": "svnMaterial1",
+  "type": "svn"
+}
+```
+
+Instead of plain `password` you may specify `encrypted_password` with encrypted content
+which usually makes more sense considering that value is stored in SCM.
+
+## Hg
+
+```json
+{
+  "url": "repos/myhg",
+  "filter": {
+    "ignore": [
+      "externals",
+      "tools"
+    ]
+  },
+  "destination": "dir1",
+  "auto_update": false,
+  "name": "hgMaterial1",
+  "type": "hg"
+}
+```
+
+## Perforce
+
+```json
+{
+  "port": "10.18.3.102:1666",
+  "username": "user1",
+  "password": "pass1",
+  "use_tickets": false,
+  "view": "//depot/dev/src...          //anything/src/...",
+  "filter": {
+    "ignore": [
+      "lib",
+      "tools"
+    ]
+  },
+  "destination": "dir1",
+  "auto_update": false,
+  "name": "p4materialName",
+  "type": "p4"
+}
+```
+
+Instead of plain `password` you may specify `encrypted_password` with encrypted content
+which usually makes more sense considering that value is stored in SCM.
+
+## Tfs
+
+```json
+{
+  "url": "url3",
+  "username": "user4",
+  "domain": "example.com",
+  "password": "pass",
+  "project": "projectDir",
+  "filter": {
+    "ignore": [
+      "tools",
+      "externals"
+    ]
+  },
+  "destination": "dir1",
+  "auto_update": false,
+  "name": "tfsMaterialName",
+  "type": "tfs"
+}
+```
+
+Instead of plain `password` you may specify `encrypted_password` with encrypted content
+which usually makes more sense considering that value is stored in SCM.
+
+## Dependency
+
+```json
+{
+  "pipeline": "pipeline2",
+  "stage": "build",
+  "name": "pipe2",
+  "type": "dependency"
+}
+```
+
+## Package
+
+```json
+{
+  "package_id": "apt-repo-id",
+  "name": "myapt",
+  "type": "package"
+}
+```
+
+## Pluggable SCM
+
+```json
+
+```

--- a/developer/writing_go_plugins/configrepo/version_1_0/parse_directory.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/parse_directory.md
@@ -30,6 +30,8 @@ This message is sent by the server, when it has completed a checkout of configur
 
 ***Expected response body***: The plugin is expected to send a response, which contains partial configuration of pipelines and environments defined in the requested directory. Plugin may also return error in response as needed.
 
+For reference on allowed pipelines and environment objects please see [config objects](config_objects.md)
+
 Note: If plugin responds with errors Go Server shows those in "server health messages" and treats configuration repository as invalid until plugin returns no errors.
 
 ***Example response***:
@@ -45,6 +47,7 @@ Note: If plugin responds with errors Go Server shows those in "server health mes
     ],
     "pipelines" : [
       {
+        "location" : "docexample.gopipeline.json",
         "label_template": "${COUNT}",
         "enable_pipeline_locking": false,
         "name": "my_pipeline",
@@ -134,9 +137,29 @@ Note: If plugin responds with errors Go Server shows those in "server health mes
     ],
     "environments" : [
       {
+          "location" : "dev.goenvironment.json",
           "name" : "dev",
           "pipelines" : [ "pipeline1" ]  
       }
     ]
 }
 ```
+
+# Parse directory response content
+
+The root object in response message contains 4 members:
+```json
+{
+  "target_version" : 1,
+  "errors": [],
+  "pipelines" : [],
+  "environments" : []
+}
+```
+
+ * `target_version` is used by Go to migrate older plugin responses
+ * `errors` can contain plugin's complaints about invalidity of configuration repository.
+ * `pipelines` is an array of pipeline objects to be defined in Go server
+ * `environments` is an array of environments to be defined in Go server
+
+ For reference on allowed pipelines and environment objects please see [config objects](config_objects.md)

--- a/developer/writing_go_plugins/configrepo/version_1_0/parse_directory.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/parse_directory.md
@@ -1,0 +1,146 @@
+## Message: Parse Directory
+
+This message is sent by the server, when it has completed a checkout of configuration repository and wants the plugin to parse it.
+
+### Request - From the server
+
+***Request name***: `parse-directory`
+
+***Request parameters***: empty
+
+***Request headers***: empty
+
+***Request body***: This contains the directory to be parsed as a JSON string:
+
+```json
+{
+  "directory" : "<full path to checkout>"
+}
+```
+
+***Example request***:
+
+```json
+{
+  "directory" : "/var/lib/go-server/pipelines/flyweight/145cefce-a972-46a6-ab40-954b08b75cf2"
+}
+```
+
+### Response - From the plugin
+
+***Expected response body***: The plugin is expected to send a response, which contains partial configuration of pipelines and environments defined in the requested directory. Plugin may also return error in response as needed.
+
+Note: If plugin responds with errors Go Server shows those in "server health messages" and treats configuration repository as invalid until plugin returns no errors.
+
+***Example response***:
+
+```json
+{
+    "errors": [
+        {
+          "location" : "mypipeline.json",
+          "message" : "file is not in JSON format"
+        }
+    ],
+    "pipelines" : [
+      {
+        "label_template": "${COUNT}",
+        "enable_pipeline_locking": false,
+        "name": "my_pipeline",
+        "tracking_tool": null,
+        "timer": null,
+        "environment_variables": [],
+        "materials": [
+          {
+            "type": "git",
+            "url": "git@github.com:example/sample_repo.git",
+            "destination": "code",
+            "filter": {
+                "ignore": [
+                        "**/*.*",
+                        "**/*.html"
+                ]
+            },
+            "name": "git",
+            "auto_update": true,
+            "branch": "master",
+            "submodule_folder": null
+          }
+        ],
+        "stages": [
+          {
+            "name": "my_stage",
+            "fetch_materials": true,
+            "clean_working_directory": false,
+            "never_cleanup_artifacts": false,
+            "approval": {
+              "type": "success",
+              "authorization": {
+                "roles": [],
+                "users": []
+              }
+            },
+            "environment_variables": [],
+            "jobs": [
+              {
+                "name": "my_job",
+                "run_instance_count": null,
+                "timeout": 0,
+                "environment_variables": [],
+                "resources": [
+                      "Linux",
+                      "Java"
+                ],
+                "tasks": [
+                  {
+                    "type": "exec",
+                    "run_if": [
+                      "passed"
+                    ],
+                    "on_cancel": {
+                      "type": "exec",
+                      "attributes": {
+                        "command": "ls",
+                        "working_directory": null
+                      }
+                    },
+                    "command": "sleep",
+                    "arguments": [
+                      "10"
+                    ],
+                    "working_directory": null
+                  }
+               ],
+                "tabs": [
+                  {
+                    "name": "cobertura",
+                    "path": "target/site/cobertura/*.xml"
+                  }
+                ],
+                "artifacts": [
+                  {
+                    "source": "target",
+                    "destination": "result",
+                    "type": "build"
+                  },
+                  {
+                    "source": "test",
+                    "destination": "res1",
+                    "type": "test"
+                  }
+                ],
+                "properties": null
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "environments" : [
+      {
+          "name" : "dev",
+          "pipelines" : [ "pipeline1" ]  
+      }
+    ]
+}
+```

--- a/developer/writing_go_plugins/configrepo/version_1_0/parse_directory.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/parse_directory.md
@@ -36,6 +36,7 @@ Note: If plugin responds with errors Go Server shows those in "server health mes
 
 ```json
 {
+    "target_version" : 1,
     "errors": [
         {
           "location" : "mypipeline.json",
@@ -47,6 +48,7 @@ Note: If plugin responds with errors Go Server shows those in "server health mes
         "label_template": "${COUNT}",
         "enable_pipeline_locking": false,
         "name": "my_pipeline",
+        "group" : "configrepo-example",
         "tracking_tool": null,
         "timer": null,
         "environment_variables": [],
@@ -75,10 +77,8 @@ Note: If plugin responds with errors Go Server shows those in "server health mes
             "never_cleanup_artifacts": false,
             "approval": {
               "type": "success",
-              "authorization": {
-                "roles": [],
-                "users": []
-              }
+              "roles": [],
+              "users": []
             },
             "environment_variables": [],
             "jobs": [
@@ -94,15 +94,11 @@ Note: If plugin responds with errors Go Server shows those in "server health mes
                 "tasks": [
                   {
                     "type": "exec",
-                    "run_if": [
-                      "passed"
-                    ],
+                    "run_if": "passed",
                     "on_cancel": {
                       "type": "exec",
-                      "attributes": {
-                        "command": "ls",
-                        "working_directory": null
-                      }
+                      "command": "ls",
+                      "working_directory": null
                     },
                     "command": "sleep",
                     "arguments": [

--- a/developer/writing_go_plugins/configrepo/version_1_0/parse_directory.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/parse_directory.md
@@ -14,7 +14,8 @@ This message is sent by the server, when it has completed a checkout of configur
 
 ```json
 {
-  "directory" : "<full path to checkout>"
+  "directory" : "<full path to checkout>",
+  "configuration": []
 }
 ```
 
@@ -22,7 +23,13 @@ This message is sent by the server, when it has completed a checkout of configur
 
 ```json
 {
-  "directory" : "/var/lib/go-server/pipelines/flyweight/145cefce-a972-46a6-ab40-954b08b75cf2"
+  "directory" : "/var/lib/go-server/pipelines/flyweight/145cefce-a972-46a6-ab40-954b08b75cf2",
+  "configuration": [
+    {
+      "key": "pipeline-pattern",
+      "value": "**/*.gopipeline.json"
+    }
+],
 }
 ```
 

--- a/developer/writing_go_plugins/configrepo/version_1_0/tasks.md
+++ b/developer/writing_go_plugins/configrepo/version_1_0/tasks.md
@@ -1,0 +1,101 @@
+# Task objects in `configrepo` extension point
+
+Every task object must have `type` field. Which can be `exec`, `ant`, `nant`, `rake`, `fetch`, `plugin`
+
+Optionally any task can have `run_if` and `on_cancel`.
+
+ * `run_if` is a string. Valid values are `passed`, `failed`, `any`
+ * `on_cancel` is a task object. Same rules apply as to tasks described on this page.
+
+### Exec
+
+```json
+{
+    "type": "exec",
+    "run_if": "passed",
+    "on_cancel" : null,
+    "command": "make",
+    "arguments": [
+      "-j3",
+      "docs",
+      "instal"
+    ],
+    "working_directory": null      
+}
+```
+
+### Ant
+
+```json
+{
+  "build_file": "mybuild.xml",
+  "target": "compile",
+  "type": "ant",
+  "run_if": "any",
+  "on_cancel" : null,
+}
+```
+
+### Nant
+
+```json
+{
+  "type": "nant",
+  "run_if": "passed",
+  "working_directory": "script/build/123",
+  "build_file": null,
+  "target": null,
+  "nant_path": null
+}
+```
+
+### Rake
+
+```json
+{
+  "type": "rake",
+  "run_if": "passed",
+  "working_directory": "sample-project",
+  "build_file": null,
+  "target": null
+}
+```
+
+### Fetch
+
+```json
+{
+   "type": "fetch",
+   "run_if": "any",
+   "pipeline": "upstream",
+   "stage": "upstream_stage",
+   "job": "upstream_job",
+   "is_source_a_file": false,
+   "source": "result",
+   "destination": "test"
+ }
+```
+
+### Plugin
+
+```json
+{
+  "type": "plugin",
+  "configuration": [
+    {
+      "key": "ConverterType",
+      "value": "jsunit"
+    },
+    {
+      "key": "password",
+      "encrypted_value": "ssd#%fFS*!Esx"
+    }
+  ],
+  "run_if": "passed",
+  "plugin_configuration": {
+    "id": "xunit.converter.task.plugin",
+    "version": "1"
+  },
+  "on_cancel": null
+}
+```

--- a/user/configuration/configuration_reference.md
+++ b/user/configuration/configuration_reference.md
@@ -43,6 +43,43 @@
         <a href="#repository">&lt;/repository&gt;</a>
     <a href="#repositories">&lt;/repositories&gt;</a>
 
+    <a href="#config-repos">&lt;config-repos&gt;</a>
+        <a href="#config-repo">&lt;config-repo&gt;</a>
+          <a href="#svn">&lt;svn&gt;</a>
+              <a href="#filter">&lt;filter&gt;</a>
+                  <a href="#ignore">&lt;ignore/&gt;</a>
+              <a href="#filter">&lt;/filter&gt;</a>
+          <a href="#svn">&lt;/svn&gt;</a>
+          <a href="#hg">&lt;hg&gt;</a>
+              <a href="#filter">&lt;filter&gt;</a>
+                  <a href="#ignore">&lt;ignore/&gt;</a>
+              <a href="#filter">&lt;/filter&gt;</a>
+          <a href="#hg">&lt;/hg&gt;</a>
+          <a href="#p4">&lt;p4&gt;</a>
+              &lt;view/&gt;
+              <a href="#filter">&lt;filter&gt;</a>
+                  <a href="#ignore">&lt;ignore/&gt;</a>
+              <a href="#filter">&lt;/filter&gt;</a>
+          <a href="#p4">&lt;/p4&gt;</a>
+          <a href="#git">&lt;git&gt;</a>
+              <a href="#filter">&lt;filter&gt;</a>
+                  <a href="#ignore">&lt;ignore/&gt;</a>
+              <a href="#filter">&lt;/filter&gt;</a>
+          <a href="#git">&lt;/git&gt;</a>
+          <a href="#tfs">&lt;tfs&gt;</a>
+              <a href="#filter">&lt;filter&gt;</a>
+                  <a href="#ignore">&lt;ignore/&gt;</a>
+              <a href="#filter">&lt;/filter&gt;</a>
+          <a href="#tfs">&lt;/tfs&gt;</a>
+          <a href="#config-repo-configuration">&lt;configuration&gt;</a>
+              <a href="#config-repo-property">&lt;property&gt;</a>
+                  <a href="#config-repo-property-key">&lt;key/&gt;</a>
+                  <a href="#config-repo-property-value">&lt;value/&gt;</a>
+              <a href="#config-repo-property">&lt;/property&gt;</a>
+          <a href="#config-repo-configuration">&lt;/configuration&gt;</a>
+        <a href="#config-repo">&lt;/config-repo&gt;</a>
+    <a href="#config-repos">&lt;/config-repos&gt;</a>
+
     <a href="#pipelines">&lt;pipelines&gt;</a>
         <a href="#group_authorization">&lt;authorization&gt;</a>
             <a href="#group_admins">&lt;admins&gt;</a>
@@ -511,6 +548,74 @@ Two users would be administrators, they are **Jez** and **lqiao**.
    <user>lqiao<user>
    <role>_readonly_member<role>
 </view>
+```
+
+
+[top](#top)
+
+## &lt;configuration repositories&gt; {#config-repos}
+
+The `<config-repos>` element is a container of package config-repos.
+
+### Example
+
+```xml
+<cruise>
+  ...
+  <config-repos>
+    <config-repo>
+      <git url="https://github.com/tomzo/gocd-indep-config-part.git" />
+    </config-repo>
+    <config-repo plugin="gocd-xml">
+      <git url="https://github.com/tomzo/gocd-refmain-config-part.git" />
+    </config-repo>
+    <config-repo plugin="gocd-xml">
+      <git url="https://github.com/tomzo/gocd-refpart-config-part.git" />
+      <configuration>
+        <property>
+          <key>pattern</key>
+          <value>*.gocd.xml</value>
+        </property>
+      </configuration>
+    </config-repo>
+    <config-repo plugin="json.config.plugin">
+      <git url="https://github.com/tomzo/gocd-json-config-example.git" />
+    </config-repo>
+  </config-repos>
+</cruise>
+```
+
+[top](#top)
+
+## &lt;configuration repository&gt; {#config-repo}
+
+The `<config-repo>` element specifies a single configuration repository. It must contain exactly one SCM material and may contain additional configuration section.
+
+### Attributes
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| plugin | No | The ID of configuration repository plugin. E.g. `json.config.plugin`. When not set, default Go XML format is used. |
+
+### Example
+
+```xml
+<cruise>
+  ...
+  <cruise>
+    ...
+    <config-repos>
+      <config-repo plugin="gocd-xml">
+        <git url="https://github.com/tomzo/gocd-refpart-config-part.git" />
+        <configuration>
+          <property>
+            <key>pattern</key>
+            <value>*.gocd.xml</value>
+          </property>
+        </configuration>
+      </config-repo>
+  </cruise>
+</cruise>
 ```
 
 [top](#top)

--- a/user/extension_points/configrepo_extension.md
+++ b/user/extension_points/configrepo_extension.md
@@ -21,7 +21,11 @@ There are certain limits involved when using configuration repository:
 Go server polls all materials from pipelines and user-defined configuration repositories.
 The final server configuration is merged from all elements defined via UI and remote elements in repositories.
 It is important to pay attention to errors introduced in repositories. Go behavior changes once there are errors in at least one of the repositories. It is **highly recommended** to remove any errors as soon as Go reports them. For configuration repositories the only way to so is by pushing changes to faulty repository.
-All configuration errors are displayed
+All configuration errors are displayed in server health messages.
+
+#### Merging configurations - conflicts
+
+TODO: Merging environments, groups, environment var. behavior and conflicts
 
 ## References:
 

--- a/user/extension_points/configrepo_extension.md
+++ b/user/extension_points/configrepo_extension.md
@@ -23,9 +23,37 @@ The final server configuration is merged from all elements defined via UI and re
 It is important to pay attention to errors introduced in repositories. Go behavior changes once there are errors in at least one of the repositories. It is **highly recommended** to remove any errors as soon as Go reports them. For configuration repositories the only way to so is by pushing changes to faulty repository.
 All configuration errors are displayed in server health messages.
 
-#### Merging configurations - conflicts
+#### Pipeline groups
 
-TODO: Merging environments, groups, environment var. behavior and conflicts
+Pipelines can be defined in many configuration repositories. Each has no restrictions
+on group that it should belong to. So if you have group `project1` and many configuration
+repositories with pipelines that all declare belonging to group `project1` then in Go server
+all these pipelines will show up in group `project1`.
+
+#### Environments
+
+Similarly to pipeline groups, final members of environments are a sum of elements in
+all configuration repositories. E.g.
+ * in repository A we can define that `pipeline1` is member of environment `development`
+ * in repository B we can define that `pipeline2` and `pipeline3` is member of environment `development`
+ * in repository C we can define that `pipeline3` is member of environment `development`
+
+Then final pipelines in environment `development` are `pipeline1`, `pipeline2`, `pipeline3`.
+Notice that `pipeline3` membership in environment `development` was declared twice.
+
+Same approach is used for agents.
+
+Environment variables have additional check. If you assign same environment variable
+with 2 different values then it is considered configuration merge conflict.
+
+#### Conflicts
+
+In some situations it is not possible to create merged configuration from configuration repositories
+and main Go configuration. Server health messages will report **Invalid Merged Configuration** then.
+
+The common cases that will cause this error are:
+ * pipelines with same name are declared in many configuration repositories.
+ * one of the pipelines refers to non-existing pipeline. Or more generally some configuration element refers to other that does not exist.
 
 ## References:
 

--- a/user/extension_points/configrepo_extension.md
+++ b/user/extension_points/configrepo_extension.md
@@ -1,0 +1,32 @@
+# Configuration repository Extension
+
+## Overview
+
+Go supports (as beta feature) writing configuration plugins starting 16.2.0.
+
+Configuration plugins allow users to keep **pipeline and environment** configurations
+in all version control systems supported by Go.
+
+The format in which configurations are stored is fully controlled by the plugin,
+so pipelines and environments can be stored for example in JSON, YAML, XML, dot files or any convention that can store necessary information.
+
+There are certain limits involved when using configuration repository:
+
+ * It is not possible to edit remote pipeline or environment using UI
+ * Elements defined via UI cannot refer to remote ones. The other way around is possible.
+ * Pipeline templates and parameters are not supported
+
+### Merging configurations
+
+Go server polls all materials from pipelines and user-defined configuration repositories.
+The final server configuration is merged from all elements defined via UI and remote elements in repositories.
+It is important to pay attention to errors introduced in repositories. Go behavior changes once there are errors in at least one of the repositories. It is **highly recommended** to remove any errors as soon as Go reports them. For configuration repositories the only way to so is by pushing changes to faulty repository.
+All configuration errors are displayed
+
+## References:
+
+* [Developer docs](http://www.go.cd/documentation/developer/writing_go_plugins/configrepo/json_message_based_configrepo_extension.html)
+* [Configuration repository plugins](http://www.go.cd/community/plugins.html#configuration-repository-plugins)
+* [Github issue](https://github.com/gocd/gocd/issues/1133) including very long debate on how Go should behave
+* [Example configuration repository in JSON](https://github.com/tomzo/gocd-json-config-example)
+* [Example configuration repository in XML](https://github.com/tomzo/gocd-indep-config-part)

--- a/user/extension_points/index.md
+++ b/user/extension_points/index.md
@@ -22,6 +22,11 @@ See [this](task_extension.md) for details about the task extension point. Go doe
 
 See [this](notification_extension.md) for details about the notification extension point. Go does not have a bundled notification extension. You can see [Email notification extension](https://github.com/srinivasupadhya/email-notifier) for reference.
 
+# Configuration repository Extension
+
+See [this](configrepo_extension.md) for details about the configuration repository extension point. You can see [JSON config plugin](https://github.com/tomzo/gocd-json-config-example) for reference.
+Using extension point is not necessary to have pipeline configuration stored in version control. Go supports configuration repository content written in format which follows XML server configuration.
+
 # Note
 
 - You can find more extensions in the community [plugins listing page](http://www.go.cd/community/plugins.html).


### PR DESCRIPTION
#211 

 * Added XML config reference
 * added some description on how extension point can be used
 * added examples of json objects that should be returned by config repos plugins. Most of the JSON examples are taken from what is generated and used in tests.