### PR TITLE
Disabling uglify grunt task as an indirect dependency.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,16 +26,6 @@ var path = require("path");
         }]
       }
     },
-    uglify: {
-      dist: {
-        files: [{
-            expand: true,
-            cwd: '<%= docs.source %>',
-            src: '**/*.js',
-            dest: '<%= docs.destination %>'
-        }]
-      }
-    },
     cssmin: {
       dist: {
         files: [{
@@ -49,10 +39,9 @@ var path = require("path");
     }
   });
 
-  grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-htmlmin');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
 
-  grunt.registerTask('default', ['htmlmin', 'uglify', 'cssmin']);
+  grunt.registerTask('default', ['htmlmin', 'cssmin']);
 
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "grunt-cli": "^0.1.13",
     "grunt": "^0.4.5",
     "grunt-contrib-cssmin": "^0.13.0",
-    "grunt-contrib-htmlmin": "^0.4.0",
-    "grunt-contrib-uglify": "^0.9.1"
+    "grunt-contrib-htmlmin": "^0.4.0"
   }  
 }


### PR DESCRIPTION
(jsdom) fails on eslint syntax.